### PR TITLE
Moved Saving video functionality from Collector to own process

### DIFF
--- a/argussight/core/collector.py
+++ b/argussight/core/collector.py
@@ -1,12 +1,7 @@
 import redis
-import os
-from argussight.core.config import CollectorConfiguration, SaveFormat
-from PIL import Image
+from argussight.core.config import CollectorConfiguration
 import json
 import base64
-from collections import deque
-import cv2
-import numpy as np
 from multiprocessing.managers import DictProxy
 from multiprocessing.synchronize import Lock
 
@@ -14,57 +9,17 @@ class Collector:
     def __init__(self, config: CollectorConfiguration, shared_dict: DictProxy, lock: Lock):
         self._client = redis.StrictRedis(host=config.redis.host, port=config.redis.port)
         self._channel = config.redis.channel
-        self._max_queue_length = config.queue.max_length
-        self._queue = deque(maxlen=self._max_queue_length)
         self.shared_dict = shared_dict
         self.lock = lock
-        self._save_folder = config.queue.save_folder
-        self._save_format = config.queue.save_format
-
-        if not os.path.exists(self._save_folder):
-            os.makedirs(self._save_folder, exist_ok=True)
-
-    def save_frame(self, frame: dict, folder_path: str):
-        img = Image.frombytes("RGB", frame['size'], frame['data'], "raw")
-        img.save(os.path.join(folder_path, 'img'+ frame['time'] + '.jpg'), format='JPEG')
 
     def process_frame(self, frame: dict) -> None:
         # decode the received frame data before saving
         frame["data"] = base64.b64decode(frame['data'])
-        self._queue.append(frame)
         with self.lock:
             self.shared_dict['frame'] = frame['data']
             self.shared_dict['frame_number'] += 1
             self.shared_dict['time_stamp'] = frame['time']
             self.shared_dict['size'] = frame['size']
-    
-    def save_queue_as_video(self) -> None:
-        video_folder = os.path.join(self._save_folder, 'videos')
-        if not os.path.exists(video_folder):
-            os.makedirs(video_folder, exist_ok=True)
-        output_file = os.path.join(video_folder, f"video_{self._queue[0]['time']}-{self._queue[-1]['time']}.avi")
-
-        out = cv2.VideoWriter(output_file, cv2.VideoWriter_fourcc(*'MJPG') , 30, self._queue[0]['size'])
-
-        for frame in self._queue:
-            img = Image.frombytes("RGB", frame['size'], frame['data'], "raw")
-            open_cv_image = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
-            out.write(open_cv_image)
-        
-        out.release()
-        cv2.destroyAllWindows()
-
-    def save_queue(self) -> None:
-        if self._save_format == SaveFormat.FRAMES or self._save_format == SaveFormat.BOTH:
-            frames_folder = os.path.join(self._save_folder, f"frames_{self._queue[0]['time']}-{self._queue[-1]['time']}")
-            if not os.path.exists(frames_folder):
-                os.makedirs(frames_folder, exist_ok=True)
-
-            for frame in self._queue:
-                self.save_frame(frame, frames_folder)
-        
-        if self._save_format == SaveFormat.VIDEO or self._save_format == SaveFormat.BOTH:
-            self.save_queue_as_video()
 
     def start(self) -> None:
         pubsub = self._client.pubsub()
@@ -73,9 +28,5 @@ class Collector:
         for message in pubsub.listen():
             if message["type"] == "message":
 
-                if message["data"] == b'save queue':
-                    self.save_queue()
-                    continue
-                else:
-                    frame = json.loads(message["data"])
-                    self.process_frame(frame)
+                frame = json.loads(message["data"])
+                self.process_frame(frame)

--- a/argussight/core/config.py
+++ b/argussight/core/config.py
@@ -1,25 +1,13 @@
 from pydantic import BaseModel, Field
 from typing import Union
-from enum import Enum
-
-class SaveFormat(Enum):
-    VIDEO = 'video'
-    FRAMES = 'frames'
-    BOTH = 'both'
 
 class RedisConfiguration(BaseModel):
     host: str = Field("localhost", description="redis host")
     port: int = Field(6379, description="redis port")
     channel: str = Field("video-streamer", description="redis-channel to publish stream")
 
-class QueueConfiguration(BaseModel):
-    save_folder: str = Field("./queue", description="folder where to save the queue")
-    max_length: int = Field(200, description="maximal length of the queue")
-    save_format: SaveFormat = Field('both', description="format for saving the queue")
-
 class CollectorConfiguration(BaseModel):
     redis: RedisConfiguration
-    queue: QueueConfiguration
 
 def get_config_from_dict(config_data: dict) -> Union[CollectorConfiguration, None]:
     data = CollectorConfiguration(**config_data)

--- a/argussight/core/manager.py
+++ b/argussight/core/manager.py
@@ -1,0 +1,47 @@
+from multiprocessing import Queue
+from datetime import datetime
+from threading import Event
+from argussight.core.video_processes.vprocess import ProcessError
+import queue
+
+
+class Manager():
+    def __init__(self, command_queue: Queue, response_queue: Queue, finished_event: Event, failed_event: Event) -> None:
+        self._commands_list = queue.Queue(maxsize=20) # commands that are waiting to be processed by Manager
+        self._command_queue = command_queue # commands that are sent to process for being processed
+        self._response_queue = response_queue
+        self._finished_event = finished_event
+        self._failed_event = failed_event
+
+    def receive_command(self, command: str, wait_time: int, processed_event: Event, result_queue: queue.Queue, args) -> None:
+        if self._commands_list.full():
+            raise ProcessError(f"Cannot execute command {command}: too many commands in waiting list")
+        self._commands_list.put({
+            "command": command,
+            "max_wait_time": wait_time,
+            "time_stamp": datetime.now(),
+            "args": args,
+            "processed_event": processed_event,
+            "result_queue": result_queue,
+        })
+    
+    def handle_commands(self) -> None:
+        while not self._commands_list.empty():
+            command = self._commands_list.get()
+
+            # Check if command is alive
+            if (datetime.now() - command["time_stamp"]).total_seconds() > command["max_wait_time"]:
+                continue
+
+            self._command_queue.put((command["command"], command["args"]))
+            command["processed_event"].set()
+
+            try:
+                result = self._response_queue.get(timeout=command["max_wait_time"])
+                command["result_queue"].put(result)
+
+            except queue.Empty:
+                self._failed_event.set()
+                break
+        
+        self._finished_event.set()

--- a/argussight/core/video_processes/config.yaml
+++ b/argussight/core/video_processes/config.yaml
@@ -1,10 +1,20 @@
 modules_path: argussight.core.video_processes
 
 worker_classes:
-  test: vprocess.Test
-  flow_detection: flow_detection.FlowDetection
+  test: 
+    location: vprocess.Test
+    accessible: True
+  flow_detection: 
+    location: flow_detection.FlowDetection
+    accessible: True
+  video_saver: 
+    location: video_saver.VideoSaver
+    accessible: False
 
 processes:
   - name: "initial test"
     type: test
     args: []
+  - name: "Saver"
+    type: video_saver
+    args: [200, logs]

--- a/argussight/core/video_processes/flow_detection.py
+++ b/argussight/core/video_processes/flow_detection.py
@@ -2,7 +2,6 @@ import cv2
 import numpy as np
 from argussight.core.video_processes.vprocess import Vprocess, FrameFormat
 from typing import Tuple
-import time
 import yaml
 import os
 from multiprocessing.managers import DictProxy

--- a/argussight/core/video_processes/video_saver.py
+++ b/argussight/core/video_processes/video_saver.py
@@ -1,0 +1,88 @@
+from multiprocessing.managers import DictProxy
+from multiprocessing.synchronize import Lock
+from argussight.core.video_processes.vprocess import Vprocess, ProcessError
+from collections import deque
+from enum import Enum
+from PIL import Image
+import os
+import cv2
+import numpy as np
+from multiprocessing import Queue
+import queue
+from datetime import datetime
+
+class SaveFormat(Enum):
+    VIDEO = 'video'
+    FRAMES = 'frames'
+    BOTH = 'both'
+
+class VideoSaver(Vprocess):
+    def __init__(self, shared_dict: DictProxy, lock: Lock, max_queue_len, main_save_folder: str) -> None:
+        super().__init__(shared_dict, lock)
+        self._commands = {
+            "save": self.save_queue
+        }
+        self._command_timeout = 0.04
+        self._queue = deque(maxlen=max_queue_len)
+        self._main_save_folder = main_save_folder
+
+    def save_frame(self, frame: dict, folder_path: str):
+        img = Image.frombytes("RGB", frame['size'], frame['frame'], "raw")
+        img.save(os.path.join(folder_path, 'img'+ frame['time_stamp'] + '.jpg'), format='JPEG')
+
+    def save_queue_as_video(self, save_folder) -> None:
+        video_folder = os.path.join(save_folder, 'videos')
+        if not os.path.exists(video_folder):
+            os.makedirs(video_folder, exist_ok=True)
+        output_file = os.path.join(video_folder, f"video_{self._queue[0]['time_stamp']}-{self._queue[-1]['time_stamp']}.avi")
+
+        out = cv2.VideoWriter(output_file, cv2.VideoWriter_fourcc(*'MJPG') , 30, self._queue[0]['size'])
+
+        for frame in self._queue:
+            img = Image.frombytes("RGB", frame['size'], frame['frame'], "raw")
+            open_cv_image = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
+            out.write(open_cv_image)
+        
+        out.release()
+        cv2.destroyAllWindows()
+    
+    def is_within_main(self, target):
+        abs_main = os.path.abspath(self._main_save_folder)
+        abs_target = os.path.abspath(target)
+        
+        common_prefix = os.path.commonpath([abs_main])
+        target_prefix = os.path.commonpath([abs_main, abs_target])
+        
+        return common_prefix == target_prefix
+
+    def save_queue(self, save_format: str, personnal_folder: str) -> None:
+        save_folder = os.path.join(self._main_save_folder, personnal_folder)
+        if not self.is_within_main(save_folder):
+            raise ProcessError("Your path should not leave the main folder")
+        print(f"saving video at {save_folder}")
+        if save_format == SaveFormat.FRAMES.value or save_format == SaveFormat.BOTH.value:
+            frames_folder = os.path.join(save_folder, f"frames_{self._queue[0]['time_stamp']}-{self._queue[-1]['time_stamp']}")
+            if not os.path.exists(frames_folder):
+                os.makedirs(frames_folder, exist_ok=True)
+
+            for frame in self._queue:
+                self.save_frame(frame, frames_folder)
+        
+        if save_format == SaveFormat.VIDEO.value or save_format == SaveFormat.BOTH.value:
+            self.save_queue_as_video(save_folder)
+
+    def run(self, command_queue: Queue, response_queue: Queue) -> None:
+        while True:
+            try:
+                order, args = command_queue.get(timeout=self._command_timeout)
+                self.handle_command(order, response_queue, args)
+            except queue.Empty:
+                change = False
+                with self.lock:
+                    current_frame_number = self.shared_dict["frame_number"]
+                    if self._current_frame_number != current_frame_number:
+                        current_frame = dict(self.shared_dict)
+                        change = True
+                if change:
+                    current_frame["time_stamp"] = datetime.strptime(current_frame["time_stamp"], self._date_format).strftime(self._date_format)
+                    self._queue.append(current_frame)

--- a/argussight/core/video_processes/vprocess.py
+++ b/argussight/core/video_processes/vprocess.py
@@ -33,13 +33,14 @@ class Vprocess:
         self._time_stamp_used = False # If you need self._current_frame_time, set this to true
         self._commands = {} # Dictionary of all commands that can be executed via command_queue
         self._command_timeout = 1 # Time the process waits for new commands to arrive in seconds
+        self._date_format = "%H:%M:%S.%f"
     
     def read_frame(self) -> bool:
         with self.lock:
             current_frame_number = self.shared_dict["frame_number"]
             if self._current_frame_number != current_frame_number:
                 if self._time_stamp_used:
-                    self.format_time(self.shared_dict['time_stamp'])
+                    self._current_frame_time = datetime.strptime(self.shared_dict['time_stamp'], self._date_format)
 
                 self.copy_frame(self.shared_dict["frame"], self.shared_dict["size"])
                 if self._current_frame_number != -1:
@@ -52,10 +53,6 @@ class Vprocess:
                 return True
         
         return False
-    
-    def format_time(self, timestamp: str) -> None:
-        date_format = "%H:%M:%S.%f"
-        self._current_frame_time = datetime.strptime(timestamp, date_format)
     
     def copy_frame(self, frame_data: bytes, frame_size: Tuple[int, int, int]) -> None:
         match self._frame_format:

--- a/argussight/grpc/test_client.py
+++ b/argussight/grpc/test_client.py
@@ -3,6 +3,7 @@ import argussight.grpc.argus_service_pb2 as pb2
 import argussight.grpc.argus_service_pb2_grpc as pb2_grpc
 import json
 import time
+from argussight.core.video_processes.video_saver import SaveFormat
 
 def run():
     channel = grpc.insecure_channel('localhost:50051')
@@ -33,6 +34,13 @@ def run():
 
     print("Sending handle request for test process")
     response = stub.ManageProcesses(pb2.ManageProcessesRequest(name='Remote Test', order='change_roi', wait_time=5, args=[json.dumps([500, 500, 300, 450])]))
+    print(response.status, response.error_message)
+
+    print("Waiting for 5 seconds...")
+    time.sleep(5)
+
+    print("Sending handle request for saving process")
+    response = stub.ManageProcesses(pb2.ManageProcessesRequest(name='Saver', order='save', wait_time=30, args=[json.dumps(SaveFormat.BOTH.value), json.dumps("./test")]))
     print(response.status, response.error_message)
 
     print("Waiting 5 seconds...")

--- a/argussight/main.py
+++ b/argussight/main.py
@@ -1,7 +1,7 @@
 import argparse
 import multiprocessing
 
-from argussight.core.config import get_config_from_dict, SaveFormat
+from argussight.core.config import get_config_from_dict
 from argussight.core.collector import Collector
 from argussight.grpc.server import serve
 
@@ -40,37 +40,10 @@ def parse_args() -> None:
         default='video-streamer',
     )
 
-    opt_parser.add_argument(
-        "-qml",
-        "--queue-max-length",
-        dest='queue_max_length',
-        help="maximal number of frames saved in the queue",
-        default="200",
-    )
-
-    opt_parser.add_argument(
-        "-s",
-        "--save",
-        dest="save_folder",
-        help="path to folder to save the queue",
-        default='./logs/queue',
-    )
-
-    opt_parser.add_argument(
-        "-f",
-        "--format",
-        dest="format",
-        help="Format to save the queue to. Allowed values: 'video', 'frames' or 'both'",
-        default='both',
-    )
-
     return opt_parser.parse_args()
 
 def run() -> None:
     args = parse_args()
-
-    if args.format not in SaveFormat._value2member_map_:
-        raise ValueError(f"Invalid value: {args.format}. Allowed values are: {[value.value for value in SaveFormat]}")
 
     config = get_config_from_dict(
         {
@@ -78,11 +51,6 @@ def run() -> None:
                 "host": args.host,
                 "port": args.port,
                 "channel": args.channel,
-            },
-            "queue":{
-                "save_folder": args.save_folder,
-                "max_length": args.queue_max_length,
-                "save_format": args.format 
             }
         }
     )


### PR DESCRIPTION
This PR is linked to #4. 
It moves the save video functionality from collector to an own Vprocess. This functionality is meant to be used in case of errors occuring to save the last few seconds of the video before this happening. 

Additionally, I added restricted classes to the spawner, the idea is that this process will always be running, if an error occurs in the process, they will be restarted, otherwise they cannot be started or terminated via Server request and should be defined in the server config, so that the server can start them at the beginning.

Also the paths that are given from requests for saving must be inside a server defined main folder (If you do not try to exit the main folder by including "../" to your path for example, your path will always be in the main folder) otherwise, you cannot save. To restrict memory access from server requests.