### PR TITLE
added Streamer class in hierarchy

### DIFF
--- a/argussight/core/configurations/config.yaml
+++ b/argussight/core/configurations/config.yaml
@@ -7,7 +7,7 @@ worker_classes:
     location: vprocess.Test
     accessible: true
   flow_detection:
-    location: detection_algorithms.optical_flow_detection.OpticalFlowDetection
+    location: streamer.optical_flow_detection.OpticalFlowDetection
     accessible: true
   stream_buffer:
     location: savers.stream_buffer.StreamBuffer

--- a/argussight/core/configurations/processes/detection_algorithms/streamer.yaml
+++ b/argussight/core/configurations/processes/detection_algorithms/streamer.yaml
@@ -1,0 +1,3 @@
+---
+
+parameters: {}

--- a/argussight/core/video_processes/streamer/streamer.py
+++ b/argussight/core/video_processes/streamer/streamer.py
@@ -1,0 +1,86 @@
+from typing import Any, Dict
+import redis
+import json
+import queue
+import uuid
+from multiprocessing import Queue
+import base64
+import subprocess
+import cv2
+
+from argussight.core.video_processes.vprocess import Vprocess, FrameFormat
+
+
+class Streamer(Vprocess):
+    def __init__(
+        self, collector_config, free_port, exposed_parameters: Dict[str, Any]
+    ) -> None:
+        super().__init__(collector_config, exposed_parameters)
+
+        self._processed_frame = None  # this should be changed in process_frame
+        self._frame_format = (
+            FrameFormat.CV2
+        )  # streamer processes should use the cv2 (BGR) image format
+
+        self._stream_id = str(uuid.uuid1())
+        self._redis_client = redis.StrictRedis(host="localhost", port=6379)
+        self._currently_streaming = False
+        self.free_port = free_port
+
+    def get_stream_id(self) -> str:
+        return self._stream_id
+
+    def run(self, command_queue: Queue, response_queue: Queue) -> None:
+        pubsub = self._client.pubsub()
+        pubsub.subscribe(self._channel)
+
+        try:
+            for message in pubsub.listen():
+                try:
+                    order, args = command_queue.get(timeout=self._command_timeout)
+                    self.handle_command(order, response_queue, args)
+                except queue.Empty:
+                    pass
+
+                if message and message["type"] == "message":
+                    self.read_frame(json.loads(message["data"]))
+                    self.process_frame()
+                    self.stream()
+        except redis.exceptions.ConnectionError as e:
+            print(f"Connection error {e} by {type(self)}")
+
+    def stream(self) -> None:
+        if self._processed_frame is not None:
+            _, buffer = cv2.imencode(".jpg", self._processed_frame)
+            raw_image_data = buffer.tobytes()
+            frame_dict = {
+                "data": base64.b64encode(raw_image_data).decode("utf-8"),
+                "size": self._processed_frame.shape,
+            }
+            self._redis_client.publish(self._stream_id, json.dumps(frame_dict))
+            if not self._currently_streaming:
+                self._video_stream_process = subprocess.Popen(
+                    [
+                        "video-streamer",
+                        "-uri",
+                        "redis://localhost:6379",
+                        "-hs",
+                        "localhost",
+                        "-p",
+                        "90" + str(self.free_port),  # temp
+                        "-q",
+                        "4",
+                        "-s",
+                        str(self._processed_frame.shape[0:2])
+                        .replace("(", "")
+                        .replace(")", ""),
+                        "-of",
+                        "MPEG1",
+                        "-id",
+                        self._stream_id,
+                        "-irc",
+                        self._stream_id,
+                    ],
+                    close_fds=True,
+                )
+                self._currently_streaming = True


### PR DESCRIPTION
The new streamer class is a direct subclass from `vprocess` and is meant to be used as ancestor class for other classes. It waits for the process to set and change the `self._processed_frame` attribute and then creates a stream using the `video-streamer`.  Taking charge of everything concerning the stream including streaming on the correct port and generating unique stream ids.
`Spawner` has been modified, so that it will directly check if your process is a subclass of `Streamer` and chooses a port for streaming in that case.