### PR TITLE
make a read-only recording setting

### DIFF
--- a/argussight/core/video_processes/vprocess.py
+++ b/argussight/core/video_processes/vprocess.py
@@ -139,7 +139,7 @@ class Vprocess:
     def prepare_setting_change(self, key: str) -> None:
         pass
 
-    def _get_all_parameters(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def _get_all_parameters(self) -> Dict[str, Any]:
         all_params = {
             param: data["value"]
             for param, data in self._config.get("parameters", {}).items()

--- a/argussight/grpc/helper_functions.py
+++ b/argussight/grpc/helper_functions.py
@@ -2,7 +2,7 @@ import json
 from google.protobuf.any_pb2 import Any
 
 
-def pack_to_any(value):
+def pack_to_any(value: any) -> Any:
     any_obj = Any()
 
     if isinstance(value, str):
@@ -11,6 +11,9 @@ def pack_to_any(value):
     elif isinstance(value, (dict, list)):
         json_value = json.dumps(value)
         any_obj.value = json_value.encode("utf-8")
+
+    elif isinstance(value, (int, float, bool)):
+        any_obj.value = str(value).encode("utf-8")
 
     # Handle other cases if needed (like numbers, custom types, etc.)
     else:
@@ -21,8 +24,25 @@ def pack_to_any(value):
 
 def unpack_from_any(any_obj):
     try:
-        # Attempt to decode as a UTF-8 string (could be a simple string or JSON)
+        # Attempt to decode as a UTF-8 string
         decoded_value = any_obj.value.decode("utf-8")
+
+        if decoded_value == "True":
+            return True
+        elif decoded_value == "False":
+            return False
+
+        # check if int
+        if decoded_value.isdigit() or (
+            decoded_value[0] == "-" and decoded_value[1:].isdigit()
+        ):
+            return int(decoded_value)
+
+        # try to check if it is a float
+        try:
+            return float(decoded_value)
+        except ValueError:
+            pass
 
         # If it looks like JSON, parse it
         try:


### PR DESCRIPTION
This PR adds a read-only setting to the saver processes. Since the setting can only be set by calling the resp. method (stop/start for Recorder for example), it is not allowed to change the setting via change_settings method. When sending a change settings request, this should be taken into account.

While at it, I added additional support for the `pack_to_any` and `unpack_from_any` functions, to support `boolean`, `int` and `float` types. 