### PR TITLE
added max_recording time parameter

### DIFF
--- a/argussight/core/configurations/processes/savers/video_recorder.yaml
+++ b/argussight/core/configurations/processes/savers/video_recorder.yaml
@@ -16,3 +16,7 @@ parameters:
   personnal_folder:
     value: "test"
     exposed: true
+  max_recording_time:
+    # unit: seconds, 0 means not set
+    value: 0
+    exposed: false

--- a/argussight/core/configurations/processes/savers/video_saver.yaml
+++ b/argussight/core/configurations/processes/savers/video_saver.yaml
@@ -10,3 +10,7 @@ parameters:
   personnal_folder:
     value: "test"
     exposed: true
+  max_recording_time:
+    # unit: seconds, 0 means not set
+    value: 0
+    exposed: false

--- a/argussight/core/video_processes/savers/stream_buffer.py
+++ b/argussight/core/video_processes/savers/stream_buffer.py
@@ -24,3 +24,9 @@ class StreamBuffer(VideoSaver):
 
     def add_to_iterable(self, frame: Dict) -> None:
         self._queue.append(frame)
+
+    def _max_recording_callback(self) -> None:
+        self.save_queue()
+        # this should normally not be called but if it is,
+        # there is no way to reset recording except by restarting the server
+        self._parameters["recording"] = False

--- a/argussight/core/video_processes/savers/video_recorder.py
+++ b/argussight/core/video_processes/savers/video_recorder.py
@@ -75,6 +75,8 @@ class Recorder(VideoSaver):
         if not self._parameters["recording"]:
             raise ProcessError("There is no recording to stop")
 
+        self._parameters["max_recording_time"] = None
+
         image_names = [
             os.path.join(self._parameters["temp_folder"], os.path.basename(image))
             for image in glob.glob(
@@ -114,3 +116,6 @@ class Recorder(VideoSaver):
         all_params = super()._get_all_parameters()
         all_params["recording"] = self.exposed_parameters["recording"]
         return all_params
+
+    def _max_recording_callback(self) -> None:
+        self.stop_record()


### PR DESCRIPTION
This PR introduces the `max_recording_time` parameter to all saving processes, it allows to set the maximum time for recording, where 0 means no limit. 

When it triggers, the `mac_recording_callback` method is called, be sure to overwrite it in subclasses if a class should correctly use this functionality